### PR TITLE
use node-gyp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ build: bin
 	
 bin:
 	mkdir -p ${RELEASE}
-	# remove --dest-cpu ia32 to compile in x64 on 64bit host
-	node-gyp configure --dest-cpu ia32
+	node-gyp configure --dest-cpu=${ARCH}
 	node-gyp build
 	cp build/Release/gcinfo.node ${RELEASE}
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ build: bin
 bin:
 	mkdir -p ${RELEASE}
 	# remove --dest-cpu ia32 to compile in x64 on 64bit host
-	node-waf configure --dest-cpu ia32
-	node-waf build
+	node-gyp configure --dest-cpu ia32
+	node-gyp build
 	cp build/Release/gcinfo.node ${RELEASE}
 
 test: build/Release/gcinfo.node


### PR DESCRIPTION
cc @bnoordhuis 

Really just like the title says. No more node-waf so use node-gyp.
